### PR TITLE
break-on-access.js: Add URL so users don't need to

### DIFF
--- a/break-on-access.js
+++ b/break-on-access.js
@@ -1,3 +1,6 @@
+/* From:
+   https://github.com/paulirish/break-on-access/blob/master/break-on-access.js
+ */
 function breakOn(obj, propertyName, mode, func) {
     // this is directly from https://github.com/paulmillr/es6-shim
     function getPropertyDescriptor(obj, name) {


### PR DESCRIPTION
I mean, who doesn't want to track where they got a snippet from?

The funny layout enables this workflow in Chrome devtools:

 1. Triple click on the URL to select the whole line

 2. Open the context menu

 3. Choose the "Go to ..." action

(Thankfully, this ignores the indentation and newline.)